### PR TITLE
merge package template from arlac77/npm-package-template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ before_script:
   - npm install -g --production coveralls codecov
 script:
   - npm run cover
+  - npm run lint
+  - npm run docs
 after_script:
   - codecov
   - cat ./build/coverage/lcov.info | coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![npm](https://img.shields.io/npm/v/github-repository-provider.svg)](https://www.npmjs.com/package/github-repository-provider)
-[![Greenkeeper badge](https://badges.greenkeeper.io/arlac77/github-repository-provider.svg)](https://greenkeeper.io/)
+[![Greenkeeper](https://badges.greenkeeper.io/arlac77/github-repository-provider.svg)](https://greenkeeper.io/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/arlac77/github-repository-provider)
+[![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![Build Status](https://secure.travis-ci.org/arlac77/github-repository-provider.png)](http://travis-ci.org/arlac77/github-repository-provider)
 [![bithound](https://www.bithound.io/github/arlac77/github-repository-provider/badges/score.svg)](https://www.bithound.io/github/arlac77/github-repository-provider)
 [![codecov.io](http://codecov.io/github/arlac77/github-repository-provider/coverage.svg?branch=master)](http://codecov.io/github/arlac77/github-repository-provider?branch=master)

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "pretest": "rollup -c tests/rollup.config.js",
     "precover": "rollup -c tests/rollup.config.js",
     "posttest": "npm run prepare && markdown-doctest",
-    "docs": "jsdoc2md --configure doc/jsdoc.json -l off -t doc/README.hbs -f src/*.js >README.md",
+    "docs": "documentation readme src/github-repository-provider.js --section=API",
     "semantic-release": "semantic-release",
-    "prepare": "rollup -c"
+    "prepare": "rollup -c",
+    "lint": "documentation lint src/github-repository-provider.js"
   },
   "repository": {
     "type": "git",
@@ -27,15 +28,13 @@
   },
   "devDependencies": {
     "ava": "^0.24.0",
-    "babel-preset-env": "^1.6.1",
-    "jsdoc-babel": "^0.3.0",
-    "jsdoc-to-markdown": "^3.0.2",
     "markdown-doctest": "^0.9.1",
     "nyc": "^11.4.1",
     "rollup": "^0.53.0",
     "rollup-plugin-multi-entry": "^2.0.2",
     "semantic-release": "^11.0.2",
-    "xo": "^0.19.0"
+    "xo": "^0.19.0",
+    "documentation": "^5.3.5"
   },
   "release": {},
   "keywords": [


### PR DESCRIPTION
package.json
---
- chore(devDependencies): remove jsdoc-babel@^0.3.0
- chore(devDependencies): remove jsdoc-to-markdown@^3.0.2
- chore(devDependencies): add documentation@^5.3.5 from template
- chore(scripts): update docs@documentation readme src/github-repository-provider.js --section=API from template
- chore(scripts): add lint@documentation lint src/github-repository-provider.js from template

.travis.yml
---
- chore(travis): merge from template .travis.yml

README.md
---
- docs(README): update from template
